### PR TITLE
docs(smartUI): Smart Ignore caps, iframes guide, hooks updates

### DIFF
--- a/docs/smartui-handle-videos.md
+++ b/docs/smartui-handle-videos.md
@@ -270,6 +270,8 @@ await smartuiSnapshot(driver, 'Video Page');
 2. If issues persist, consider using `ignoreDOM` for iframe areas
 3. Check if iframe content is accessible (CORS policies may affect this)
 
+For same-origin vs cross-origin iframes and automation **frame** context, see [Iframes and Embedded Content in SmartUI](/support/docs/smartui-iframes-and-embedded-content/).
+
 </TabItem>
 </Tabs>
 

--- a/docs/smartui-hooks-layout-fullpage-smartignore.md
+++ b/docs/smartui-hooks-layout-fullpage-smartignore.md
@@ -2,12 +2,13 @@
 id: smartui-hooks-layout-fullpage-smartignore
 title: SmartUI Hooks - Layout, Full Page, and Smart Ignore
 sidebar_label: Hooks Layout + Full Page
-description: Configure SmartUI Hooks for layout testing, full-page screenshots, and Smart Ignore strategy using Selenium capabilities and hook scripts.
+description: Configure SmartUI Hooks for layout testing, full-page screenshots, and Smart Ignore using Selenium capabilities—including smartUI.smartIgnore for Java.
 keywords:
   - smartui hooks
   - layout testing hooks
   - full page screenshot hooks
   - smart ignore hooks
+  - smartUI.smartIgnore
   - ignoreType
 url: https://www.testmuai.com/support/docs/smartui-hooks-layout-fullpage-smartignore/
 site_name: TestMu AI
@@ -21,16 +22,19 @@ This guide explains the recommended SmartUI Hooks setup when you want to:
 
 - run visual checks directly from automation (without `smartui exec` wrapper),
 - capture full-page screenshots,
-- switch comparison strategy between Layout and Smart Ignore.
+- switch comparison strategy between **Layout** and **Smart Ignore**.
 
-## How Hooks Strategy Works
+## How hooks strategy works
 
-In Hooks flow, strategy is controlled primarily by capabilities (`ignoreType`) and project settings.  
-The screenshot hook script usually carries only the screenshot name (or name plus config in supported runtimes).
+In the **Hooks** flow, comparison strategy comes from **LambdaTest / `LT:Options` capabilities** (and your SmartUI project context). The screenshot hook (`executeScript`) usually supplies the screenshot name (or a small config object). **Capability names must match what the grid expects**—typos or legacy keys are a common reason Smart Ignore does not turn on.
 
-## 1. Capability Setup (Hooks)
+:::info Smart Ignore vs Ignore DOM / Select DOM
+With the **Smart Ignore** strategy, use either **Ignore DOM** or **Select DOM** in the product where those options apply. **Do not combine Ignore DOM and Select DOM together** for the same flow; pick one approach. Mixing both is unsupported and does not match best practices.
+:::
 
-Set these in your LambdaTest capability object:
+## 1. Capability setup (Hooks)
+
+### Layout strategy (example)
 
 ```json
 {
@@ -45,13 +49,59 @@ Set these in your LambdaTest capability object:
 }
 ```
 
-Notes:
+- Use `ignoreType: ["layout"]` (with the rest of your layout options) for **layout-only** comparisons.
 
-- Use `ignoreType: ["layout"]` for layout-only comparisons.
-- For Smart Ignore, change strategy to `ignoreType: ["smartignore"]` (or `smart-ignore` if your account parser uses that token).
-- Keep the same strategy in baseline and comparison runs.
+### Smart Ignore strategy (Selenium Java) — recommended
 
-## 2. Full-Page Screenshot in Hooks
+For **Selenium with Java** and Hooks, enable Smart Ignore for the session by setting **`smartUI.smartIgnore`** to **`true`** on your **`LT:Options`** map (not only `ignoreType`).
+
+```java
+import java.util.HashMap;
+import org.openqa.selenium.chrome.ChromeOptions;
+
+ChromeOptions browserOptions = new ChromeOptions();
+HashMap<String, Object> ltOptions = new HashMap<>();
+ltOptions.put("username", System.getenv("LT_USERNAME"));
+ltOptions.put("accessKey", System.getenv("LT_ACCESS_KEY"));
+ltOptions.put("visual", true);
+ltOptions.put("smartUI.project", "Your_Project_Name");
+// Enables Smart Ignore for this run (baseline capture and comparisons)
+ltOptions.put("smartUI.smartIgnore", true);
+
+browserOptions.setCapability("LT:Options", ltOptions);
+```
+
+Apply the **same** `smartUI.project` and **`smartUI.smartIgnore`: true** when you capture the **baseline** and when you run **non-baseline** builds. Changing strategy mid-stream without a new baseline will produce confusing diffs.
+
+### Smart Ignore (JSON / Node-style `LT:Options`)
+
+```javascript
+'LT:Options': {
+  visual: true,
+  'smartUI.project': 'Your_Project_Name',
+  'smartUI.smartIgnore': true,
+},
+```
+
+### C# (Hooks)
+
+```csharp
+capabilities.SetCapability("visual", true);
+capabilities.SetCapability("smartUI.project", "Your_Project_Name");
+capabilities.SetCapability("smartUI.smartIgnore", true);
+```
+
+:::warning Deprecated or ineffective patterns (do not use for Smart Ignore)
+The following are **not** sufficient on their own to enable Smart Ignore in typical Selenium Java Hooks sessions, and they match common presales confusion:
+
+- `ltOptions.put("ignoreType", Arrays.asList("smartignore"));` **without** `smartUI.smartIgnore`
+- `ltOptions.put("smartignore", true);` at the root of `LT:Options` (wrong key)
+- Relying only on UI project toggles while capabilities still imply **strict / pixel** behavior for the build
+
+Use **`smartUI.smartIgnore`: `true`** as shown above, keep baseline and compare runs aligned, then re-run.
+:::
+
+## 2. Full-page screenshot in hooks
 
 ### Name-only hook (widely supported)
 
@@ -83,60 +133,45 @@ var cfg = new Dictionary<string, object>
 ((IJavaScriptExecutor)driver).ExecuteScript("smartui.takeScreenshot", cfg);
 ```
 
-## 3. Enable Smart Ignore in Hooks
+For **Smart Ignore**, prefer session-level **`smartUI.smartIgnore`** in `LT:Options` rather than pushing `smartignore` only inside ad-hoc hook config objects.
 
-Smart Ignore is a strategy, not a standalone boolean flag.
+## 3. Baseline and comparison requirements
 
-- Recommended: set capability `ignoreType` to Smart Ignore strategy.
-- Do not depend on `smartignore: true` as the primary method.
+1. Same **`smartUI.project`**.
+2. Same **screenshot names** between runs.
+3. Same **comparison strategy**: for Smart Ignore, **`smartUI.smartIgnore`: true** on both baseline and comparison sessions (and avoid mixing with conflicting DOM-override modes).
+4. If you change strategy or major options, **recapture baseline**.
 
-### Example (C#)
+## 4. Strict comparison vs Smart Ignore
 
-```csharp
-capabilities.SetCapability("visual", true);
-capabilities.SetCapability("smartUI.project", "Your_Project_Name");
-capabilities.SetCapability("ignoreType", new[] { "smartignore" });
+If the build or project is effectively using **strict (pixel-to-pixel) comparison** as the dominant mode, some Smart Ignore–centric workflows (for example certain **baseline diff** experiences in the UI) **do not apply** the same way. **Smart Ignore–first behavior** (including the capabilities above) is what unlocks the intended Smart Ignore comparison path. Align **dashboard project comparison options** with your automation caps when customers refuse to use per-screenshot UI toggles.
 
-var smartUiOptions = new Dictionary<string, object>
-{
-    { "ignoreType", new[] { "smartignore" } }
-};
-capabilities.SetCapability("smartUI.options", smartUiOptions);
-```
+## 5. Why your name appears on every build
 
-### Example (Java)
+Builds executed with a **project token** (or default org identity) often show the **project creator** as the actor. To attribute runs differently where the product allows it, configure the **username**, **access key**, and **project name** / token context as appropriate for that automation user—not the personal account used to create the project, if that is not desired.
 
-```java
-HashMap<String, Object> ltOptions = new HashMap<>();
-ltOptions.put("visual", true);
-ltOptions.put("smartUI.project", "Your_Project_Name");
-ltOptions.put("ignoreType", Arrays.asList("smartignore"));
-```
-
-## 4. Baseline and Comparison Requirements
-
-To get correct comparison results:
-
-1. Use the same `smartUI.project`.
-2. Use the same screenshot names between runs.
-3. Use the same strategy (`layout` or `smartignore`) for baseline and comparison.
-4. If strategy changes, recapture baseline.
-
-## 5. Best Practices for Hooks
+## 6. Best practices for hooks
 
 - Keep screenshot names deterministic, for example: `page_viewport_1366x768`.
-- Use one shared build name for all viewport sessions in a single run.
+- Use one shared **build name** for all viewport sessions in a single run where applicable.
 - Wait for page stabilization before triggering screenshot hooks.
 - Include viewport in screenshot name if running responsive coverage.
-- Prefer capability-level strategy control over script-level overrides.
+- For Smart Ignore on Java Hooks, treat **`smartUI.smartIgnore`** as the source of truth at the capability layer.
 
-## 6. Troubleshooting
+## 7. Troubleshooting
 
-### Strategy not applied
+### Smart Ignore still not applied (Java / Selenium)
 
-- Verify `ignoreType` is present in the actual session capabilities.
-- Ensure baseline was captured with the same strategy.
-- Check project-level comparison settings in SmartUI dashboard.
+1. Confirm **`smartUI.smartIgnore`** is **`true`** in the **final** session capabilities (not only in a discarded map).
+2. Confirm **baseline** was taken with **`smartUI.smartIgnore`: true** as well.
+3. Remove conflicting keys: avoid stacking **Ignore DOM** and **Select DOM** patterns against Smart Ignore guidance.
+4. Confirm you are not expecting Smart Ignore–only UI behavior while the build is still in an effective **strict** comparison context.
+
+### Strategy not applied (general)
+
+- Verify capabilities on the session in LambdaTest automation logs.
+- Check **project-level** comparison defaults in the SmartUI dashboard.
+- After doc or product updates, refresh any cached examples—older snippets may show `ignoreType` alone for Smart Ignore.
 
 ### "Please provide screenshot name"
 
@@ -155,7 +190,7 @@ To get correct comparison results:
 - Confirm same screenshot name and same project on both runs.
 - Confirm second run is uploaded to the intended branch/build context.
 
-## Related Docs
+## Related docs
 
 - [Layout Testing](/support/docs/smartui-layout-testing/)
 - [Smart Ignore](/support/docs/smartui-smartignore/)

--- a/docs/smartui-iframes-and-embedded-content.md
+++ b/docs/smartui-iframes-and-embedded-content.md
@@ -1,0 +1,93 @@
+---
+id: smartui-iframes-and-embedded-content
+title: Iframes and Embedded Content in SmartUI
+sidebar_label: Iframes & Embeds
+description: How SmartUI treats same-origin and cross-origin iframes for screenshots and comparison, with practical tips for videos, widgets, and automation context.
+keywords:
+  - SmartUI iframe
+  - embedded content
+  - cross-origin iframe
+  - visual regression iframe
+  - SmartUI YouTube embed
+  - TestMu AI SmartUI
+url: https://www.testmuai.com/support/docs/smartui-iframes-and-embedded-content/
+site_name: TestMu AI
+slug: smartui-iframes-and-embedded-content/
+canonical: https://www.testmuai.com/support/docs/smartui-iframes-and-embedded-content/
+---
+
+import BrandName, { BRAND_URL } from '@site/src/component/BrandName';
+
+<script type="application/ld+json"
+      dangerouslySetInnerHTML={{ __html: JSON.stringify({
+       "@context": "https://schema.org",
+        "@type": "BreadcrumbList",
+        "itemListElement": [{
+          "@type": "ListItem",
+          "position": 1,
+          "name": "Home",
+          "item": BRAND_URL
+        },{
+          "@type": "ListItem",
+          "position": 2,
+          "name": "Support",
+          "item": `${BRAND_URL}/support/docs/`
+        },{
+          "@type": "ListItem",
+          "position": 3,
+          "name": "Iframes and Embedded Content in SmartUI",
+          "item": `${BRAND_URL}/support/docs/smartui-iframes-and-embedded-content/`
+        }]
+      })
+    }}
+></script>
+
+# Iframes and Embedded Content in SmartUI
+
+Pages often include **iframes**: embedded apps, chat widgets, consent managers, or **video players** (YouTube, Vimeo). SmartUI captures what the **browser paints** in your <BrandName /> session. How much you can **inspect or target in the DOM** depends on whether the iframe is **same-origin** or **cross-origin** with the top page.
+
+## Same-origin vs cross-origin
+
+| Case | What you can expect |
+|------|---------------------|
+| **Same-origin iframe** | The child document is part of your site’s origin. **Viewport / full-page** captures usually include the iframe’s rendered area. **Element locators** for nodes inside the iframe work from automation **after** you switch the driver into that frame (see below). |
+| **Cross-origin iframe** | Browser security **blocks** parent JavaScript from reading the child document (similar to CORS). **Pixels** of the iframe’s **on-screen box** can still appear in screenshots if the embed renders. **DOM-based** tooling in the parent page **cannot** see inside the third-party document. |
+
+SmartUI does not override the browser’s security model; plan comparisons accordingly.
+
+## Video and media embeds
+
+For **`<video>`** elements and **embedded players** (often in iframes), SmartUI’s **first-frame** behavior and troubleshooting are documented here:
+
+- [Handle Pages with Videos](/support/docs/smartui-handle-videos/) — includes guidance when **embedded videos via iframe** misbehave, **`ignoreDOM`** on the iframe region, and **CORS / accessibility** of iframe content.
+
+## Element screenshots and frame context
+
+When you use **SmartUI Hooks** to capture a **specific element** (for example [`smartui-hooks-element-screenshot`](/support/docs/smartui-hooks-element-screenshot/)), locators are resolved in the **current WebDriver browsing context**.
+
+- To capture a node **inside** an iframe, **switch into that frame** first (for example Selenium `driver.switchTo().frame(...)`), then run the hook against the element in that document.
+- If you stay on the **top** document, selectors that only exist inside the iframe will not resolve.
+
+## Full-page and viewport captures
+
+**Full-page** and **viewport** screenshots reflect the **composed** page the browser draws. Same-origin iframes generally composite like any other content. Cross-origin embeds still draw a **rectangle**; what appears inside it depends on the embed loading, cookies, and network—so baselines can be **noisier** than static HTML.
+
+**Mitigations:** explicit waits, stable viewport size, and **`ignoreDOM`** (or annotations) on the iframe **container** when the embed is intentionally out of scope for the test.
+
+## Nested iframes
+
+Treat **nested** iframes like a stack of contexts: switch **in** level by level for inner elements, allow extra time for each document to load, and expect **more flakiness** when outer and inner origins differ.
+
+## Shadow DOM (not an iframe)
+
+**Shadow DOM** isolates markup inside a component but **same origin** as the host page. SmartUI’s Shadow DOM support is separate from iframe behavior:
+
+- [Shadow DOM](/support/docs/smartui-shadow-dom/)
+
+## Related docs
+
+- [Handle Pages with Videos](/support/docs/smartui-handle-videos/)
+- [Take a Screenshot of a Specific Element (Hooks)](/support/docs/smartui-hooks-element-screenshot/)
+- [Shadow DOM](/support/docs/smartui-shadow-dom/)
+- [Handling Dynamic Data](/support/docs/smartui-handle-dynamic-data/)
+- [Troubleshooting Guide](/support/docs/smartui-troubleshooting-guide/)

--- a/docs/smartui-smartignore.md
+++ b/docs/smartui-smartignore.md
@@ -81,9 +81,11 @@ This allows you to selectively apply Smart Ignore to specific screenshots, makin
   className='doc_img'
 />
 
-#### 3. Using Smart Ignore in Hooks Flow (Automation Capabilities)
+#### 3. Using Smart Ignore in Hooks flow (automation capabilities)
 
-If you are using SmartUI Hooks (for example Selenium `executeScript("smartui.takeScreenshot=...")` style), enable Smart Ignore using `ignoreType` in capabilities.
+If you use **SmartUI Hooks** (for example Selenium `executeScript("smartui.takeScreenshot=...")`), enable Smart Ignore from **`LT:Options`** using **`smartUI.smartIgnore`: `true`**. That is the supported switch for subsequent builds (baseline and comparison should both use the same setting).
+
+**Node / JavaScript example**
 
 ```javascript
 const capabilities = {
@@ -93,14 +95,24 @@ const capabilities = {
     accessKey: process.env.LT_ACCESS_KEY,
     visual: true,
     'smartUI.project': 'My-Project',
-    ignoreType: ['smartignore']
-  }
+    'smartUI.smartIgnore': true,
+  },
 };
 ```
 
-> Smart Ignore is a strategy mode. Prefer `ignoreType` strategy configuration over a standalone `smartignore: true` flag.
+**Selenium Java** — set on your `HashMap` (or equivalent) passed as `LT:Options`:
 
-For full Hooks examples with Layout, Full Page, and Smart Ignore, see:
+```java
+ltOptions.put("smartUI.smartIgnore", true);
+```
+
+:::warning Avoid these alone for Hooks + Java
+Using only `ignoreType: ['smartignore']`, or a root-level `smartignore: true` key, often **does not** enable Smart Ignore the way the grid expects. Use **`smartUI.smartIgnore`** as above. See the full matrix in [Hooks: Layout + Full Page + Smart Ignore](/support/docs/smartui-hooks-layout-fullpage-smartignore/).
+:::
+
+With the Smart Ignore strategy, use either **Ignore DOM** or **Select DOM** where the product offers them—**not both at once**.
+
+For full Hooks examples (layout, full page, troubleshooting, strict mode notes), see:
 - [Hooks: Layout + Full Page + Smart Ignore](/support/docs/smartui-hooks-layout-fullpage-smartignore/)
 
 ## Use Cases of Smart Ignore

--- a/sidebars.js
+++ b/sidebars.js
@@ -4096,6 +4096,11 @@ module.exports = {
           },
           {
             type: "doc",
+            label: "Iframes & Embeds",
+            id: "smartui-iframes-and-embedded-content",
+          },
+          {
+            type: "doc",
             label: "Handle Lazy Loading",
             id: "smartui-handle-lazy-loading",
           },


### PR DESCRIPTION
## Summary
- **Hooks / Smart Ignore:** Document `smartUI.smartIgnore: true` for Selenium Java and LT:Options; add warning for ineffective patterns (`ignoreType` alone, root `smartignore` flag). Updates [SmartUI Hooks - Layout, Full Page, and Smart Ignore](https://www.testmuai.com/support/docs/smartui-hooks-layout-fullpage-smartignore/) and the Hooks section on [Smart Ignore](https://www.testmuai.com/support/docs/smartui-smartignore/).
- **Iframes:** New short guide [Iframes and Embedded Content](https://www.testmuai.com/support/docs/smartui-iframes-and-embedded-content/) (same vs cross-origin, frame context for element screenshots, links to Handle Videos and Shadow DOM).
- **Sidebar:** Register **Iframes & Embeds** under Stabilize Screenshots.
- **Handle Videos:** Cross-link from embedded-video troubleshooting to the iframes doc.

## Testing
- [ ] `npm run build` (optional) — markdown-only changes.

Refs: internal Smart Ignore capability clarification (TE-13131 / presales); iframe handling analysis for CS.

Made with [Cursor](https://cursor.com)