### PR TITLE
docs(smartUI): Hooks layout vs capabilities + P2P settings disclaimer

### DIFF
--- a/docs/accessibility-choosing-the-right-tool.md
+++ b/docs/accessibility-choosing-the-right-tool.md
@@ -209,7 +209,7 @@ Pair screen reader sessions with [Keyboard Scan](/support/docs/accessibility-key
 
 **Rule repositories:** [Web](/support/docs/accessibility-web-rule-repository/) · [Android](/support/docs/accessibility-android-rule-repository/) · [iOS](/support/docs/accessibility-ios-rule-repository/).
 
-**Compliance framing (not legal advice):** [Accessibility Compliance Guide](/support/docs/accessibility-compliance-guide/) · [VPAT Report Generation](/support/docs/accessibility-vpat-report-generation/).
+**Compliance framing (not legal advice):** [Accessibility Compliance Guide](/support/docs/accessibility-compliance-guide/) · [VPAT and ACR evidence (customer-owned templates)](/support/docs/accessibility-vpat-report-generation/) (TestMu AI does **not** provide VPAT or ACR reports).
 
 ---
 

--- a/docs/accessibility-compliance-guide.md
+++ b/docs/accessibility-compliance-guide.md
@@ -31,10 +31,10 @@ Accessibility Testing supports compliance workflows, but automated results alone
 1. **WCAG** is the technical baseline—map automated findings to success criteria using **[Web](/support/docs/accessibility-web-what-we-cover/)**, **[iOS](/support/docs/accessibility-ios-what-we-cover/)**, and **[Android](/support/docs/accessibility-android-what-we-cover/)** checklists plus rule repositories.
 2. **ADA / EAA / 508 conversations** still require **manual evidence** (keyboard-only paths, screen readers, policy docs). Use Accessibility outputs as **inputs**, not the final legal position.
 3. Establish a **definition of done**: e.g., “no open critical/serious automated issues on core journeys + documented manual matrix.”
-4. For procurement or VPAT work, pair this guide with **[VPAT Report Generation](/support/docs/accessibility-vpat-report-generation/)** and **[Supported WCAG Versions & Browsers](/support/docs/accessibility-supported-wcag-browsers/)**.
+4. For procurement or VPAT-style evidence work, pair this guide with **[VPAT and ACR evidence (customer-owned templates)](/support/docs/accessibility-vpat-report-generation/)**—TestMu AI does **not** provide VPAT or ACR reports—and **[Supported WCAG Versions & Browsers](/support/docs/accessibility-supported-wcag-browsers/)**.
 
 ## Related docs
 
 - [Supported WCAG Versions & Browsers](/support/docs/accessibility-supported-wcag-browsers/)
-- [VPAT Report Generation](/support/docs/accessibility-vpat-report-generation/)
+- [VPAT and ACR evidence (customer-owned templates)](/support/docs/accessibility-vpat-report-generation/)
 - [Web Accessibility Coverage](/support/docs/accessibility-web-what-we-cover/)

--- a/docs/accessibility-vpat-report-generation.md
+++ b/docs/accessibility-vpat-report-generation.md
@@ -1,8 +1,8 @@
 ---
 id: accessibility-vpat-report-generation
-title: VPAT Report Generation
-sidebar_label: VPAT Report Generation
-description: End-to-end workflow for using Accessibility Testing outputs as evidence toward a VPAT—scope, scans, manual verification, exports, and what still requires human sign-off.
+title: VPAT and ACR evidence (customer-owned templates)
+sidebar_label: VPAT & ACR evidence
+description: TestMu AI does not provide VPAT or ACR reports. Use Accessibility Testing to gather evidence while your organization completes official ITI VPAT or ACR templates separately.
 slug: accessibility-vpat-report-generation/
 url: https://www.testmuai.com/support/docs/accessibility-vpat-report-generation/
 site_name: TestMu AI
@@ -14,15 +14,22 @@ keywords:
   - WCAG conformance
   - accessibility procurement
   - audit evidence
+  - no VPAT report
 ---
 
-# VPAT Report Generation
+# VPAT and ACR evidence (customer-owned templates)
+
+:::danger TestMu AI does not provide VPAT or ACR deliverables
+**TestMu AI does not issue, host, or ship an official VPAT® document or Accessibility Conformance Report (ACR)** as a product output. There is **no** “download VPAT” or “generate VPAT” action in the platform that replaces your organization’s own procurement or accessibility documentation.
+
+What you **do** get from **Accessibility Testing** are **testing artifacts**—issues, severities, URLs or screens, exports, integrations—that **you** may choose to cite while **your team** completes the official **ITI VPAT** (or equivalent) and assigns **Conformance** levels. This page is only a **workflow guide** for that evidence work.
+:::
 
 A **Voluntary Product Accessibility Template (VPAT®)** is a structured way to document how a product meets accessibility criteria (commonly WCAG 2.x and/or Section 508 / EN 301 549, depending on the template version you use). Buyers and compliance teams use it in **procurement** and **audit** conversations.
 
-**TestMu AI Accessibility Testing** can speed up **evidence collection**—issue lists, severities, URLs or screens, remediation notes, and exports—but it does **not** auto-generate a finished VPAT. Filling the official template, assigning **Conformance** levels per criterion, and signing off for your organization remain **human** steps, often with accessibility specialists and legal review.
+**TestMu AI Accessibility Testing** can speed up **evidence collection**—issue lists, severities, URLs or screens, remediation notes, and exports—but it does **not** auto-generate a finished VPAT or ACR. Filling the official template, assigning **Conformance** levels per criterion, and signing off for your organization remain **human** steps, often with accessibility specialists and legal review.
 
-This page walks **end to end** from scoping a release to packaging outputs that feed VPAT-style tables. It is **not legal advice**; treat it as a practical bridge between product workflows and VPAT preparation.
+This page walks **end to end** from scoping a release to packaging outputs that **you** can reference when drafting VPAT-style tables **outside** the product. It is **not legal advice**; treat it as a practical bridge between product workflows and VPAT preparation.
 
 ## What a VPAT is (and is not)
 
@@ -31,6 +38,7 @@ This page walks **end to end** from scoping a release to packaging outputs that 
 | A standardized **product disclosure** of accessibility characteristics | A certificate that your product is “fully accessible” |
 | A table-oriented document aligned to **specific criteria** (WCAG success criteria, 508 clauses, etc.) | A single PDF export from any one tool |
 | Something **your organization** completes and stands behind | Something automated scans alone can complete |
+| | An official VPAT or ACR **delivered by TestMu AI** (the platform does not provide these reports) |
 
 Official templates and guidance are maintained by **ITI (Information Technology Industry Council)**. Your team chooses the right edition (e.g. WCAG 2.x, Section 508, EN 301 549) for the markets and contracts you care about.
 
@@ -93,7 +101,7 @@ VPAT readers expect evidence beyond automation.
 
 1. Have an **accessibility SME** verify that table wording matches evidence and that no criterion is marked **Supports** without documented manual or automated coverage.
 2. Route through **legal or procurement** per your company policy before sharing externally.
-3. Version the VPAT document (e.g. `VPAT_ProductName_2026-04_v1.pdf`) and store it with the underlying export bundle.
+3. Version **your organization’s** VPAT or ACR file (e.g. `VPAT_ProductName_2026-04_v1.pdf`) and store it with the underlying **TestMu AI export** bundle for traceability.
 
 ## Mapping product outputs to VPAT-style rows
 

--- a/docs/accessibility-web-score.md
+++ b/docs/accessibility-web-score.md
@@ -138,4 +138,4 @@ For fix order and rule context, use the **[Accessibility Issue Remediation Guide
 - [Passed Test Cases](/support/docs/accessibility-passed-test-cases/)  
 - [Exporting & Sharing Reports](/support/docs/accessibility-exporting-sharing-reports/)  
 - [Accessibility Compliance Guide (ADA / WCAG / EAA / 508)](/support/docs/accessibility-compliance-guide/)  
-- [VPAT Report Generation](/support/docs/accessibility-vpat-report-generation/)  
+- [VPAT and ACR evidence (customer-owned templates)](/support/docs/accessibility-vpat-report-generation/)  

--- a/docs/smartui-hooks-layout-fullpage-smartignore.md
+++ b/docs/smartui-hooks-layout-fullpage-smartignore.md
@@ -2,58 +2,49 @@
 id: smartui-hooks-layout-fullpage-smartignore
 title: SmartUI Hooks - Layout, Full Page, and Smart Ignore
 sidebar_label: Hooks Layout + Full Page
-description: Configure SmartUI Hooks for layout testing, full-page screenshots, and Smart Ignore using Selenium capabilities—including smartUI.smartIgnore for Java.
+description: SmartUI Hooks on LambdaTest—layout comparison via screenshot hook options, Smart Ignore via smartUI.smartIgnore in LT:Options, and full-page capture.
 keywords:
   - smartui hooks
   - layout testing hooks
   - full page screenshot hooks
   - smart ignore hooks
   - smartUI.smartIgnore
-  - ignoreType
+  - ignoreType layout hooks
 url: https://www.testmuai.com/support/docs/smartui-hooks-layout-fullpage-smartignore/
 site_name: TestMu AI
 slug: smartui-hooks-layout-fullpage-smartignore/
 canonical: https://www.testmuai.com/support/docs/smartui-hooks-layout-fullpage-smartignore/
 ---
 
-# SmartUI Hooks Flow: Layout Testing, Full-Page Screenshots, and Smart Ignore
+# SmartUI Hooks: Layout, Full-Page Screenshots, and Smart Ignore
 
-This guide explains the recommended SmartUI Hooks setup when you want to:
+Use this page when you run **SmartUI Hooks** on LambdaTest (for example Selenium `executeScript` without the `smartui exec` CLI wrapper) and need **layout** comparison, **full-page** capture, or **Smart Ignore**.
 
-- run visual checks directly from automation (without `smartui exec` wrapper),
-- capture full-page screenshots,
-- switch comparison strategy between **Layout** and **Smart Ignore**.
+:::danger Capability vs hook—read this first
+For **Hooks**, engineering behavior is:
 
-## How hooks strategy works
+| Goal | Where to configure | Notes |
+|------|-------------------|--------|
+| **Layout** comparison | **`smartui.takeScreenshot` hook options** (per screenshot) | Pass `ignoreType: ["layout"]` (and related layout flags) in the **Map/object** passed to `executeScript("smartui.takeScreenshot", options)`. **Layout is not enabled for Hooks by setting layout fields only in `LT:Options` capabilities**—that path is not supported the way teams often expect. |
+| **Smart Ignore** | **`LT:Options`** | Set **`smartUI.smartIgnore`: `true`** on the session for baseline and comparison runs. |
+| **Project** | **`LT:Options`** | Set **`smartUI.project`** (and `visual`, auth) as usual. |
 
-In the **Hooks** flow, comparison strategy comes from **LambdaTest / `LT:Options` capabilities** (and your SmartUI project context). The screenshot hook (`executeScript`) usually supplies the screenshot name (or a small config object). **Capability names must match what the grid expects**—typos or legacy keys are a common reason Smart Ignore does not turn on.
-
-:::info Smart Ignore vs Ignore DOM / Select DOM
-With the **Smart Ignore** strategy, use either **Ignore DOM** or **Select DOM** in the product where those options apply. **Do not combine Ignore DOM and Select DOM together** for the same flow; pick one approach. Mixing both is unsupported and does not match best practices.
+If you need **layout via capabilities alone** (no hook options), treat that as a **product / roadmap** ask—track with your account team (for example internal idea **LTPM-3632**). This doc reflects **current** Hooks behavior.
 :::
 
-## 1. Capability setup (Hooks)
+:::info Smart Ignore vs Ignore DOM / Select DOM
+With **Smart Ignore**, use either **Ignore DOM** or **Select DOM** in the dashboard where applicable—not both on the same flow.
+:::
 
-### Layout strategy (example)
+## 1. Session capabilities (`LT:Options`)
 
-```json
-{
-  "visual": true,
-  "smartUI.project": "Your_Project_Name",
-  "ignoreType": ["layout"],
-  "smartUI.options": {
-    "ignoreType": ["layout"],
-    "layout": true,
-    "captureDom": true
-  }
-}
-```
+### Always (Hooks)
 
-- Use `ignoreType: ["layout"]` (with the rest of your layout options) for **layout-only** comparisons.
+- `username`, `accessKey`, `visual: true`, **`smartUI.project`**
 
-### Smart Ignore strategy (Selenium Java) — recommended
+### Smart Ignore (Hooks)
 
-For **Selenium with Java** and Hooks, enable Smart Ignore for the session by setting **`smartUI.smartIgnore`** to **`true`** on your **`LT:Options`** map (not only `ignoreType`).
+Set on **`LT:Options`** for the whole session (baseline **and** comparison):
 
 ```java
 import java.util.HashMap;
@@ -65,25 +56,24 @@ ltOptions.put("username", System.getenv("LT_USERNAME"));
 ltOptions.put("accessKey", System.getenv("LT_ACCESS_KEY"));
 ltOptions.put("visual", true);
 ltOptions.put("smartUI.project", "Your_Project_Name");
-// Enables Smart Ignore for this run (baseline capture and comparisons)
 ltOptions.put("smartUI.smartIgnore", true);
 
 browserOptions.setCapability("LT:Options", ltOptions);
 ```
 
-Apply the **same** `smartUI.project` and **`smartUI.smartIgnore`: true** when you capture the **baseline** and when you run **non-baseline** builds. Changing strategy mid-stream without a new baseline will produce confusing diffs.
-
-### Smart Ignore (JSON / Node-style `LT:Options`)
+**JavaScript / Node**
 
 ```javascript
 'LT:Options': {
+  user: process.env.LT_USERNAME,
+  accessKey: process.env.LT_ACCESS_KEY,
   visual: true,
   'smartUI.project': 'Your_Project_Name',
   'smartUI.smartIgnore': true,
 },
 ```
 
-### C# (Hooks)
+**C#**
 
 ```csharp
 capabilities.SetCapability("visual", true);
@@ -91,19 +81,67 @@ capabilities.SetCapability("smartUI.project", "Your_Project_Name");
 capabilities.SetCapability("smartUI.smartIgnore", true);
 ```
 
-:::warning Deprecated or ineffective patterns (do not use for Smart Ignore)
-The following are **not** sufficient on their own to enable Smart Ignore in typical Selenium Java Hooks sessions, and they match common presales confusion:
+:::warning Do not use these for Smart Ignore (Hooks + Java)
+These patterns **do not** turn on Smart Ignore reliably:
 
-- `ltOptions.put("ignoreType", Arrays.asList("smartignore"));` **without** `smartUI.smartIgnore`
-- `ltOptions.put("smartignore", true);` at the root of `LT:Options` (wrong key)
-- Relying only on UI project toggles while capabilities still imply **strict / pixel** behavior for the build
+- `ltOptions.put("ignoreType", Arrays.asList("smartignore"));` without `smartUI.smartIgnore`
+- `ltOptions.put("smartignore", true);` at the root of `LT:Options`
 
-Use **`smartUI.smartIgnore`: `true`** as shown above, keep baseline and compare runs aligned, then re-run.
+Use **`smartUI.smartIgnore`: `true`** only.
 :::
 
-## 2. Full-page screenshot in hooks
+### Layout — not via standalone layout capabilities for Hooks
 
-### Name-only hook (widely supported)
+Do **not** expect **`ignoreType: ["layout"]`**, **`smartUI.layout`**, or nested **`smartUI.options`** layout blocks **alone** in `LT:Options` to enable layout comparison for Hooks. Validated behavior is: **pass layout in the hook** (next section).
+
+---
+
+## 2. Layout comparison — pass options to `smartui.takeScreenshot`
+
+Pass a **single map** to `executeScript("smartui.takeScreenshot", options)` including **`screenshotName`** and **`ignoreType`**.
+
+### Java (validated pattern)
+
+```java
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+import org.openqa.selenium.JavascriptExecutor;
+
+Map<String, Object> options = new HashMap<>();
+options.put("ignoreType", Arrays.asList("layout"));
+options.put("screenshotName", "my-layout-screenshot-01");
+
+((JavascriptExecutor) driver).executeScript("smartui.takeScreenshot", options);
+```
+
+Session **`LT:Options`** for this flow typically needs at least **`smartUI.project`** (and `visual`, credentials)—**not** a separate layout capability block for the same effect.
+
+### JavaScript
+
+```javascript
+await driver.executeScript('smartui.takeScreenshot', {
+  screenshotName: 'my-layout-screenshot-01',
+  ignoreType: ['layout'],
+});
+```
+
+### C#
+
+```csharp
+var options = new Dictionary<string, object>
+{
+    { "screenshotName", "my-layout-screenshot-01" },
+    { "ignoreType", new[] { "layout" } }
+};
+((IJavaScriptExecutor)driver).ExecuteScript("smartui.takeScreenshot", options);
+```
+
+Add **`fullPage: true`** in the same map when you need a full-page capture for that shot.
+
+---
+
+## 3. Full-page screenshot (name-only hook)
 
 ```java
 ((JavascriptExecutor) driver).executeScript("smartui.takeFullPageScreenshot=Home_Page_Desktop");
@@ -113,86 +151,43 @@ Use **`smartUI.smartIgnore`: `true`** as shown above, keep baseline and compare 
 ((IJavaScriptExecutor)driver).ExecuteScript("smartui.takeFullPageScreenshot=Home_Page_Desktop");
 ```
 
-### Config-based hook (runtime dependent)
+For **layout + full page** in one call, prefer the **config object** form in §2 with `fullPage: true` and `ignoreType: ["layout"]`.
 
-```java
-Map<String, Object> cfg = new HashMap<>();
-cfg.put("screenshotName", "Home_Page_Desktop");
-cfg.put("fullPage", true);
-cfg.put("ignoreType", Arrays.asList("layout"));
-((JavascriptExecutor) driver).executeScript("smartui.takeScreenshot", cfg);
-```
+---
 
-```csharp
-var cfg = new Dictionary<string, object>
-{
-  { "screenshotName", "Home_Page_Desktop" },
-  { "fullPage", true },
-  { "ignoreType", new[] { "layout" } }
-};
-((IJavaScriptExecutor)driver).ExecuteScript("smartui.takeScreenshot", cfg);
-```
+## 4. Baseline and comparison
 
-For **Smart Ignore**, prefer session-level **`smartUI.smartIgnore`** in `LT:Options` rather than pushing `smartignore` only inside ad-hoc hook config objects.
+1. Same **`smartUI.project`** and screenshot **names**.
+2. **Smart Ignore:** same **`smartUI.smartIgnore`** on baseline and comparison sessions.
+3. **Layout:** same **`ignoreType: ["layout"]`** (and other layout flags) in the **hook** for matching screenshot names on baseline and comparison runs.
+4. Changing strategy or options usually requires a **new baseline**.
 
-## 3. Baseline and comparison requirements
+---
 
-1. Same **`smartUI.project`**.
-2. Same **screenshot names** between runs.
-3. Same **comparison strategy**: for Smart Ignore, **`smartUI.smartIgnore`: true** on both baseline and comparison sessions (and avoid mixing with conflicting DOM-override modes).
-4. If you change strategy or major options, **recapture baseline**.
+## 5. Strict comparison vs Smart Ignore
 
-## 4. Strict comparison vs Smart Ignore
+If the project or build is still effectively in **strict (pixel) comparison**, some Smart Ignore–specific UI flows behave differently. Align dashboard **comparison mode** with session capabilities.
 
-If the build or project is effectively using **strict (pixel-to-pixel) comparison** as the dominant mode, some Smart Ignore–centric workflows (for example certain **baseline diff** experiences in the UI) **do not apply** the same way. **Smart Ignore–first behavior** (including the capabilities above) is what unlocks the intended Smart Ignore comparison path. Align **dashboard project comparison options** with your automation caps when customers refuse to use per-screenshot UI toggles.
+---
 
-## 5. Why your name appears on every build
+## 6. Build attribution (creator name)
 
-Builds executed with a **project token** (or default org identity) often show the **project creator** as the actor. To attribute runs differently where the product allows it, configure the **username**, **access key**, and **project name** / token context as appropriate for that automation user—not the personal account used to create the project, if that is not desired.
+Runs using a **project token** may show the **project creator**. Use the intended automation **username** / **access key** / **project** where the product allows.
 
-## 6. Best practices for hooks
-
-- Keep screenshot names deterministic, for example: `page_viewport_1366x768`.
-- Use one shared **build name** for all viewport sessions in a single run where applicable.
-- Wait for page stabilization before triggering screenshot hooks.
-- Include viewport in screenshot name if running responsive coverage.
-- For Smart Ignore on Java Hooks, treat **`smartUI.smartIgnore`** as the source of truth at the capability layer.
+---
 
 ## 7. Troubleshooting
 
-### Smart Ignore still not applied (Java / Selenium)
-
-1. Confirm **`smartUI.smartIgnore`** is **`true`** in the **final** session capabilities (not only in a discarded map).
-2. Confirm **baseline** was taken with **`smartUI.smartIgnore`: true** as well.
-3. Remove conflicting keys: avoid stacking **Ignore DOM** and **Select DOM** patterns against Smart Ignore guidance.
-4. Confirm you are not expecting Smart Ignore–only UI behavior while the build is still in an effective **strict** comparison context.
-
-### Strategy not applied (general)
-
-- Verify capabilities on the session in LambdaTest automation logs.
-- Check **project-level** comparison defaults in the SmartUI dashboard.
-- After doc or product updates, refresh any cached examples—older snippets may show `ignoreType` alone for Smart Ignore.
-
-### "Please provide screenshot name"
-
-- Use name directly in script string for name-only hooks:
-  - `smartui.takeScreenshot=MyName`
-  - `smartui.takeFullPageScreenshot=MyName`
-
-### Invalid C# dictionary initializer
-
-- In older C# projects, use classic dictionary syntax:
-  - `{ "key", value }`
-- Avoid mixing index initializer with old syntax in same block.
-
-### No comparison generated
-
-- Confirm same screenshot name and same project on both runs.
-- Confirm second run is uploaded to the intended branch/build context.
+| Problem | What to do |
+|--------|------------|
+| Layout never activates; only tried `LT:Options` | Move **`ignoreType: ["layout"]`** into **`smartui.takeScreenshot`** options (§2). |
+| Smart Ignore never activates | Set **`smartUI.smartIgnore`: true** in **`LT:Options`**; verify in session metadata. |
+| Tried `smartUI.layout` | Not the supported Hooks switch for layout; use hook **options** instead. |
+| Prospect cannot use dashboard toggles only | Hooks still need correct **hook** + **capability** split per this page. |
 
 ## Related docs
 
-- [Layout Testing](/support/docs/smartui-layout-testing/)
+- [Layout Comparison in SmartUI SDK](/support/docs/smartui-layout-testing/) — SDK `smartuiSnapshot` path (different from Hooks).
 - [Smart Ignore](/support/docs/smartui-smartignore/)
-- [Troubleshooting Guide](/support/docs/smartui-troubleshooting-guide/)
 - [SmartUI SDK Config Options](/support/docs/smartui-sdk-config-options/)
+- [Troubleshooting Guide](/support/docs/smartui-troubleshooting-guide/)

--- a/docs/smartui-layout-comparison.md
+++ b/docs/smartui-layout-comparison.md
@@ -83,24 +83,13 @@ Before using the Layout Comparison feature, ensure you meet the following requir
 
 Layout Comparison can be executed in two different ways depending on your integration.
 
-### 1. Using SmartUI Hooks (Native Automation)
-If you are using the SmartUI Hooks approach (triggering visual tests directly through Selenium, Playwright, or Cypress capabilities without the CLI wrapper), you must pass the `ignoreType` option within your LambdaTest capabilities (`ltOptions`). 
+### 1. Using SmartUI Hooks (native automation)
 
-Once the capability is passed, the Remote Node Client will capture the structural layout states during your session, allowing you to use the Layout Comparison mode.
+If you use **SmartUI Hooks** (visual tests through Selenium / Playwright / Cypress on the grid **without** the `smartui exec` wrapper), **layout comparison is applied per screenshot** by passing **`ignoreType: ["layout"]`** (and `screenshotName`, and optionally `fullPage`, and other layout-related keys) in the **object** you send to **`smartui.takeScreenshot`** via `executeScript`—**not** by relying on `ignoreType` or layout flags **only** inside `LT:Options`.
 
-**Example (Playwright):**
-```javascript
-const capabilities = {
-  'browserName': 'Chrome',
-  'LT:Options': {
-    'user': process.env.LT_USERNAME,
-    'accessKey': process.env.LT_ACCESS_KEY,
-    'smartUI.project': 'My-Project',
-    // Enable Layout Testing via Hook
-    'ignoreType': ['layout']
-  }
-};
-```
+For **`LT:Options`**, you still set **`smartUI.project`** (and `visual`, credentials). **Do not** assume `LT:Options.ignoreType: ['layout']` or similar capability-only snippets alone will enable layout for Hooks; that does not match current supported behavior.
+
+**See:** [SmartUI Hooks - Layout, Full Page, and Smart Ignore](/support/docs/smartui-hooks-layout-fullpage-smartignore/) for Java, JavaScript, and C# hook examples.
 
 ### 2. Using SmartUI SDK (smartUISnapshot command)
 If you are using the SmartUI SDK (`smartui exec`), you need to set the `ignoreType` option to `"layout"` when taking a specific screenshot within your code:

--- a/docs/test-settings-options.md
+++ b/docs/test-settings-options.md
@@ -31,15 +31,14 @@ import BrandName, { BRAND_URL } from '@site/src/component/BrandName';
 
 We offer multiple options for comparing the **Baseline** and the **Test Output** screenshots captured during your automation testing suites.
 
-Here are the following common test setting options -
+Here are common **pixel-to-pixel** comparison options. The first group is **actively used** through `smartUI.options` (or your framework’s equivalent) in typical integrations:
 
-- `largeImageThreshold` - Sets the pixel granularity at the rate to which the pixel blocks are created.
-- `errorType` - Show the differences in the output screen by identifying the pixel changes type and capture the intended view.
-- `ignore` - To remove the Pixel to Pixel false-positive rate in identifying the screenshot.
-- `transparency` - To help adjust test transparency settings and strike a balance between highlighting in visual screening.
-- `boundingBoxes: [box1, box2]` - By specifying a bounding box measured in pixels from the top left, you can narrow down the area of comparison.
-- `ignoredBoxes: [box1, box2]` - By specifying a bounding box measured in pixels from the top left, you can exclude part of the image from comparison.
-- `ignoreAreasColoredWith` - By specifying a RGBA color, you can exclude colored areas of the image from comparison.
+- `largeImageThreshold` — Pixel granularity for how comparison blocks are formed.
+- `errorType` — How differences are highlighted (`movement`, `flat`, etc.).
+- `ignore` — Reduces P2P false positives (`antialiasing`, `alpha`, `colors`, `nothing`).
+- `transparency` — Overlay transparency for the diff view.
+
+The sections **Bounding Boxes**, **Ignore Boxes**, and **Ignore Areas Colored** further down describe **region- and color-based** comparison ideas. Per product engineering, **those three are not reliably mapped to automation capabilities in the exact JSON shapes shown in legacy samples**—see the warning before **Bounding Boxes**. For region-level control today, prefer **[Draw on UI / annotations](/support/docs/smartui-draw-on-ui/)** or confirm the supported payload with **[support](mailto:support@testmuai.com)** before committing a prospect integration.
 
 ## Examples with comparison settings
 
@@ -234,9 +233,15 @@ let capabilities = {
 
 ---
 
+:::warning `boundingBoxes`, `ignoredBoxes`, `ignoreAreasColoredWith`
+These three comparison modes exist in SmartUI’s **pixel-to-pixel** model, but **capability-level examples below may not match what the grid accepts today**. **Do not copy them into production** without validation. Options from **Image Threshold** through **Transparency** on this page are the well-supported comparison settings. For box/color-style ignores in the UI, use **[Draw on UI](/support/docs/smartui-draw-on-ui/)** or ask support for the current API contract.
+:::
+
 ### Bounding Boxes - Compare only specific area
 
 The bounding boxes are the areas created on the screenshot which needs to be compared with the baseline ignoring other areas from the screenshot.
+
+**Reference only —** verify with support before relying on capability wiring.
 
 This specific case is used to compare only a specific area of the screenshot from the **baseline**.
 
@@ -306,6 +311,8 @@ let capabilities = {
 ---
 
 ### Ignore Boxes - Ignore only specific area
+
+**Reference only —** verify with support before relying on capability wiring.
 
 The ignored boxes are the areas created on the screenshot which needs to be ignored with the baseline comparing the other areas from the screenshot.
 
@@ -377,6 +384,8 @@ let capabilities = {
 ---
 
 ### Ignore Areas Colored - Removes the colored content from the comparison
+
+**Reference only —** verify with support before relying on capability wiring.
 
 You can exclude the pixels that match the specified color on a **baseline** image from the comparison view. This feature will ignore that specific regions with the color pixels and shows the comparison view.
 

--- a/sidebars.js
+++ b/sidebars.js
@@ -2483,7 +2483,7 @@ module.exports = {
           },
           {
             type: "doc",
-            label: "VPAT Report Generation",
+            label: "VPAT & ACR evidence",
             id: "accessibility-vpat-report-generation",
           },
         ],


### PR DESCRIPTION
## Context
- **TE-13131 / Salesforce:** Engineering confirmed **layout for Hooks** is driven by the **`smartui.takeScreenshot` hook options map** (`ignoreType: ["layout"]`, `screenshotName`, etc.), not by layout fields **only** in `LT:Options`. **Smart Ignore** remains **`smartUI.smartIgnore: true`** on `LT:Options`. Capability-only layout for Hooks is a roadmap/product discussion (e.g. **LTPM-3632**).
- **Comparison settings doc:** Engineering confirmed **`boundingBoxes`**, **`ignoredBoxes`**, and **`ignoreAreasColoredWith`** are **not properly mapped** in the doc's legacy capability shapes; other options on the page are supported.

## Changes
1. **`smartui-hooks-layout-fullpage-smartignore.md`** — Rewritten with a capability vs hook table, Java/JS/C# hook samples for layout, `smartUI.smartIgnore` section, troubleshooting (`smartUI.layout` / caps-only attempts), related links.
2. **`smartui-layout-comparison.md`** — Hooks section: remove incorrect `LT:Options.ignoreType` example; point to hooks doc.
3. **`test-settings-options.md`** — Intro split (supported vs three region/color modes); warning before Bounding Boxes; Reference only on the three sections; pointer to Draw on UI + support.

## Reviewers
@Akshay Verma @Sushobhit Dua — please confirm wording matches grid behavior.
